### PR TITLE
Use standard lib functions

### DIFF
--- a/src/common.lua
+++ b/src/common.lua
@@ -1,17 +1,6 @@
 local addonName, ns = ...
 
 -- String Helpers
-function string:Split(sep)
-  if sep == nil then
-    sep = "%s"
-  end
-  local t={}
-  for str in string.gmatch(self, "([^"..sep.."]+)") do
-      table.insert(t, str)
-  end
-  return t
-end
-
 function string:FindI(pattern)
   -- find an optional '%' (group 1) followed by any character (group 2)
   local p = pattern:gsub("(%%?)(.)", function(percent, letter)

--- a/src/common.lua
+++ b/src/common.lua
@@ -32,10 +32,6 @@ function table.ToString(t)
   return s
 end
 
-function table.RemoveLast(t)
-  table.remove (t, table.getn(t))
-end
-
 -- Interface Addon UI Components
 local uniquealyzer = 1;
 function ns.createTitle(parent, text, point, relFrame, relPoinit)

--- a/src/common.lua
+++ b/src/common.lua
@@ -23,13 +23,8 @@ function string:ToTable()
   return t or {}
 end
 
--- Table Helpers
-function table.ToString(t)
-  local s = " "
-  for k,v in pairs(t) do
-    s = s .." ".. v
-  end
-  return s
+function ns.combineCriteria(t)
+  return strjoin(" ", unpack(t))
 end
 
 -- Interface Addon UI Components

--- a/src/lfg.lua
+++ b/src/lfg.lua
@@ -49,7 +49,7 @@ function lfg.handleChatEvent(...)
   if not LFGSettings.enabled  then return value  end
   local msg, fromPlayerRealm, _, eventChannel = ...
 
-  local fromPlayer = fromPlayerRealm:Split("-")[1]  -- chat event returns "playername-servername", so we split on `-` and take the first value
+  local fromPlayer = strsplit("-", fromPlayerRealm)  -- chat event returns "playername-servername", so we split on `-` and take the first value
   local currentPlayer, realm = UnitName("player")
   if fromPlayer == currentPlayer then return end -- Ignore the Message if sent by the Player
 

--- a/src/lfg_options.lua
+++ b/src/lfg_options.lua
@@ -43,7 +43,7 @@ function lfg.loadOptions()
   lfg.panel.critAddBTN:SetSize(20 ,22) -- width, height
 
   lfg.panel.critRemoveBTN = lfg.createButton(lfg.panel, "-", "LEFT", lfg.panel.critAddBTN, "RIGHT", function()
-    table.RemoveLast(LFGSettings.criteria)
+    table.remove(LFGSettings.criteria)
     lfg.refreshInterfaceOptions(lfg.loadOptions)
   end)
   lfg.panel.critRemoveBTN:SetSize(20 ,22) -- width, height

--- a/src/lfg_options.lua
+++ b/src/lfg_options.lua
@@ -51,7 +51,7 @@ function lfg.loadOptions()
   relFrame = lfg.panel.critTitle
   for i,crit in ipairs(LFGSettings.criteria) do
     local title = lfg.createTitle(lfg.panel, "  "..i..":  ", "TOPLEFT", relFrame, "BOTTOMLEFT")
-    local eb = lfg.createEditBox(lfg.panel, table.ToString(LFGSettings.criteria[i]), "LEFT", title, "RIGHT")
+    local eb = lfg.createEditBox(lfg.panel, lfg.combineCriteria(LFGSettings.criteria[i]), "LEFT", title, "RIGHT")
     table.insert(lfg.panel.critEditBox, eb)
     relFrame = title
   end
@@ -134,7 +134,7 @@ function lfg.loadOptions()
       end
 
       for i,eb in ipairs(lfg.panel.critEditBox) do
-        eb:SetText(table.ToString(LFGSettings.criteria[i]))
+        eb:SetText(lfg.combineCriteria(LFGSettings.criteria[i]))
       end
   
       lfg.panel.inviteCB:SetChecked(LFGSettings.autoInvite)


### PR DESCRIPTION
I did some cleanup of the custom functions and substitutes them with the builtin ones.

This has several goals:
* **reduce maintenance**, the less code is written the fewer places bugs can live in;
* **increase stability**, by removing the functions from the global scope we avoid potential clashes with other addons;
* **take a step towards support of other locales**, Lua's pattern matching functions aren't friendly to non-ASCII strings, which can cause issues like [this one](https://www.curseforge.com/wow/addons/lfg-classic/issues/1), so it's better to avoid them.