### PR TITLE
Improve tracking of the channels

### DIFF
--- a/src/lfg.lua
+++ b/src/lfg.lua
@@ -47,16 +47,15 @@ end
 
 function lfg.handleChatEvent(...)
   if not LFGSettings.enabled  then return value  end
-  local msg, fromPlayerRealm, _, eventChannel = ...
+  local msg, fromPlayerRealm = ...
+  local channelNumber = select(8, ...)
 
   local fromPlayer = fromPlayerRealm:Split("-")[1]  -- chat event returns "playername-servername", so we split on `-` and take the first value
   local currentPlayer, realm = UnitName("player")
   if fromPlayer == currentPlayer then return end -- Ignore the Message if sent by the Player
 
-  for channelNumber, listening in pairs(LFGSettings.channel) do
-    if eventChannel:find(channelNumber) and listening then
-      lfg.parseMSG(msg, fromPlayer, channelNumber)
-    end
+  if LFGSettings.channel[channelNumber] then
+    lfg.parseMSG(msg, fromPlayer, channelNumber)
   end
 
 end


### PR DESCRIPTION
Use the index of the channel instead of matching
on the full name of the channel.

This prevents a bug in such a rare scenario:
if a user has more than 10 channels and has asked
to listen to channel 1, he will also listen
to channels 11, 12, etc due to substring matching.